### PR TITLE
Add thumbnail/full_size_picture fields to FormUrl

### DIFF
--- a/src/components/DescriptionPictures.tsx
+++ b/src/components/DescriptionPictures.tsx
@@ -42,7 +42,8 @@ function DescriptionPictures(props: DescriptionPicturesProps) {
             if (formUrl.dimensions) {
                 newPictureSizes[index] = formUrl.dimensions;
             } else {
-                const cancelablePromise = makeCancelablePromise<PictureSize>(getImageSize(formUrl.src));
+                const thumbnailUrl = formUrl.thumbnail || formUrl.src;
+                const cancelablePromise = makeCancelablePromise<PictureSize>(getImageSize(thumbnailUrl));
                 cancelablePromises.push(cancelablePromise);
 
                 cancelablePromise.promise
@@ -63,10 +64,12 @@ function DescriptionPictures(props: DescriptionPicturesProps) {
         };
     }, [pictures]);
 
-    const pictureUris = React.useMemo(() => pictures.map((formUrl) => formUrl.src), [pictures]);
+    const pictureUris = React.useMemo(() => {
+        return pictures.map((formUrl) => formUrl.full_size_picture || formUrl.src);
+    }, [pictures]);
 
     // There are no pictures to render
-    if (!pictureUris.length) return null;
+    if (!pictures.length) return null;
 
     return (
         <View>
@@ -80,13 +83,14 @@ function DescriptionPictures(props: DescriptionPicturesProps) {
             )}
 
             <View style={[{ flex: 1, alignItems: 'center' }, props.containerStyle]}>
-                {pictureUris.map((uri, index) => {
+                {pictures.map((formUrl, index) => {
                     if (!pictureSizes[index]) return null;
 
                     const { height, width } = pictureSizes[index];
+                    const thumbnailUrl = formUrl.thumbnail || formUrl.src;
                     return (
                         <TouchableHighlight
-                            key={uri}
+                            key={thumbnailUrl}
                             onPress={() => {
                                 setDisplayViewer(true);
                                 setViewerIndex(index);
@@ -95,7 +99,7 @@ function DescriptionPictures(props: DescriptionPicturesProps) {
                             disabled={!ImageViewer}
                         >
                             <Image
-                                source={{ uri }}
+                                source={{ uri: thumbnailUrl }}
                                 style={[
                                     { marginBottom: 15, height, width, maxHeight: 300, resizeMode: 'contain' },
                                     props.pictureStyle,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export interface CancelablePromise<T> {
 
 interface FormUrl {
     readonly src: string;
+    readonly thumbnail?: string;
+    readonly full_size_picture?: string;
     readonly name?: string;
     readonly size?: number;
     readonly dimensions?: {


### PR DESCRIPTION
Add optional thumbnail and full_size_picture fields to FormUrl.
If they are specified, the thumbnail url will be rendered in the component
and the full_size_picture passed on to the image viewer when the user touches a picture.
This makes it possible to display thumbnails in the form and only load the full-size picture
when the users opens the image viewer ; thus making the initial load faster.
It also makes it possible to display smaller pictures in the form body,
to make it more readable on smaller phones