### PR TITLE
[CROWD-167] Fix DescriptionPictures

### DIFF
--- a/src/components/DescriptionPictures.tsx
+++ b/src/components/DescriptionPictures.tsx
@@ -88,11 +88,15 @@ function DescriptionPictures(props: DescriptionPicturesProps) {
                         <TouchableHighlight
                             key={uri}
                             onPress={() => {
-                                setDisplayViewer(true);
-                                setViewerIndex(index);
-                                onPressPicture && onPressPicture(index);
+                                if (ImageViewer) {
+                                    setDisplayViewer(true);
+                                    setViewerIndex(index);
+                                }
+                                if (onPressPicture) {
+                                    onPressPicture(index);
+                                }
                             }}
-                            disabled={!ImageViewer}
+                            disabled={!ImageViewer && !onPressPicture}
                         >
                             <Image
                                 source={{ uri }}


### PR DESCRIPTION
DescriptionPictures Touchables were disabled if there was no ImageViewer prop even though there could be a onPressPicture prop